### PR TITLE
fix: unlock page

### DIFF
--- a/src/Cogworks.ContentGuard/Web/UI/App_Plugins/Cogworks.ContentGuard/js/contentguard.controller.js
+++ b/src/Cogworks.ContentGuard/Web/UI/App_Plugins/Cogworks.ContentGuard/js/contentguard.controller.js
@@ -84,6 +84,8 @@
 
                   overlayService.open(overlay);
                 });
+            } else {
+              unlockCurrentPage();
             }
           }
 


### PR DESCRIPTION
Unlock page if page wasn't changed (dirty flag).

Fix: https://trello.com/c/tzPAbBoe/347-content-guard-issue-with-spinning-button-on-content-guard-tab