### PR TITLE
fix: content guard tab order

### DIFF
--- a/src/Cogworks.ContentGuard/Web/UI/App_Plugins/Cogworks.ContentGuard/package.manifest
+++ b/src/Cogworks.ContentGuard/Web/UI/App_Plugins/Cogworks.ContentGuard/package.manifest
@@ -1,9 +1,9 @@
-﻿{
+{
   "contentApps": [
     {
       "name": "Content Guard",
       "alias": "contentGuard",
-      "weight": 1,
+      "weight": 101,
       "icon": "icon-shield",
       "view": "~/App_Plugins/Cogworks.ContentGuard/views/guard-content.html",
       "show": [


### PR DESCRIPTION
<!--
Thank you for your pull request, #h5yr! But it's just a beginning. 
Please provide details where it's required and review the requirements below.
-->
**What this PR does / why it's submitted / why we need it**:

Moved Content Guard to be last item in tabs (after Info tab(100 order weight) - 101).

We can consider in the future to change text message in view if content is not blocked TBD.


Edge case on creating new pages, issue here + workaround:
 * https://our.umbraco.com/forum/using-umbraco-and-getting-started/100532-umbraco-8-content-app-issue-creating-new-pages-only-with-no-content-fields
 * https://github.com/umbraco/Umbraco-CMS/issues/7415

Order change:
![image](https://user-images.githubusercontent.com/29370044/114553830-5913d000-9c66-11eb-895c-1305fd63a20d.png)


Related issues: https://github.com/thecogworks/Cogworks.ContentGuard/issues/13

---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My PR has a descriptive title (not a vague title like `Needed this`)
- [x] Title and all the commits follow [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [x] My PR targets the `develop` branch or appropriate `release` branch
- [ ] I've placed the link to the corresponding Trello card or issue which this PR fixes/address below ⤵️

---

Fixes: ### ISSUE_OR_TRELLO_LINK ###